### PR TITLE
Fix No ipv6 Through bug

### DIFF
--- a/lean-lede/x86_64/.config
+++ b/lean-lede/x86_64/.config
@@ -3102,9 +3102,9 @@ CONFIG_PACKAGE_kmod-nls-utf8=y
 #
 # CONFIG_PACKAGE_kmod-arptables is not set
 CONFIG_PACKAGE_kmod-br-netfilter=y
-# CONFIG_PACKAGE_kmod-ebtables is not set
-# CONFIG_PACKAGE_kmod-ebtables-ipv4 is not set
-# CONFIG_PACKAGE_kmod-ebtables-ipv6 is not set
+CONFIG_PACKAGE_kmod-ebtables=y
+CONFIG_PACKAGE_kmod-ebtables-ipv4=y
+CONFIG_PACKAGE_kmod-ebtables-ipv6=y
 # CONFIG_PACKAGE_kmod-ebtables-watchers is not set
 CONFIG_PACKAGE_kmod-ip6tables=y
 # CONFIG_PACKAGE_kmod-ip6tables-extra is not set
@@ -6170,7 +6170,7 @@ CONFIG_PACKAGE_nfs-kernel-server-utils=y
 # CONFIG_PACKAGE_arptables is not set
 # CONFIG_PACKAGE_conntrack is not set
 # CONFIG_PACKAGE_conntrackd is not set
-# CONFIG_PACKAGE_ebtables is not set
+CONFIG_PACKAGE_ebtables=y
 # CONFIG_PACKAGE_fwknop is not set
 # CONFIG_PACKAGE_fwknopd is not set
 # CONFIG_PACKAGE_ip6tables is not set


### PR DESCRIPTION
Test Shell:
ebtables -t broute -A BROUTING -p ! ipv6 -j DROP -i eth1
//Only allow ip6 Pass.
brctl addif br-lan eth1
//Bridging LAN to eth1,eth0 is Lan,eth1is Wan.
/etc/init.d/odhcpd stop
/etc/init.d/odhcpd disable
//Enable ipv6 Through,Shut down the odhcpd service & br-lan IPv6 option disabled.